### PR TITLE
Improve discovery

### DIFF
--- a/attribute.js
+++ b/attribute.js
@@ -6,7 +6,7 @@ module.exports = class attribute {
 		this.mqtt_handler = mqtt;
 
 		this.last_update = 0;
-		this.last_value = 0;
+		this.last_value = null;
 		this.update_interval = 0;
 
 		this.plc_address = null;

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,5 @@
+# $schema: ./config_schema.json
+
 ---
 update_time: 10000
 temperature_interval: 900000
@@ -93,3 +95,21 @@ devices:
     state: 
       plc: DB56,X150.0
       set_plc: DB56,X150.1
+
+  # Example of a device with two entities
+  - device_name: DevTest Sensor 1
+    name: Temperatur
+    manufacturer: Psi-Systems
+    type: sensor
+    state: DB4,INT48
+    unit_of_measurement: "°C"
+    value_template: "{{ (value | float / 10) | round(2) }}"
+    device_class: temperature
+
+  - device_name: DevTest Sensor 1
+    name: Humidity
+    type: sensor
+    state: DB4,INT50
+    unit_of_measurement: "%"
+    value_template: "{{ (value | float / 10) | round(2) }}"
+    device_class: humidity

--- a/device.js
+++ b/device.js
@@ -113,6 +113,9 @@ module.exports = class device {
 					this.config["device_identifier"]
 				]
 			};
+			if(this.config["manufacturer"]) {
+				info.device.manufacturer = this.config["manufacturer"];
+			}
 		}
 
 		this.mqtt_handler.publish(topic, JSON.stringify(info), {

--- a/device_factory.js
+++ b/device_factory.js
@@ -28,7 +28,12 @@ module.exports = function deviceFactory(devices, plc, mqtt, config, mqtt_base) {
 	if (config["mqtt"]) {
 		mqtt_name = config["mqtt"];
 	} else {
-		mqtt_name = name.toLowerCase().split(' ').join('_').split('/').join('_').split('-').join('_');
+		let rawMqttName = name;
+		if (config.device_name) {
+			// Support the composition of device_name and (entity) name
+			rawMqttName = config.device_name + " " + name;
+		}
+		mqtt_name = rawMqttName.toLowerCase().split(' ').join('_').split('/').join('_').split('-').join('_');
 	}
 	// check for double names if exists log a warning
 

--- a/devices/sensor.js
+++ b/devices/sensor.js
@@ -30,17 +30,25 @@ module.exports = class devSensor extends device {
 		if (this.attributes["state"]) {
 			info.state_topic = this.attributes["state"].full_mqtt_topic;
 
-			// optional unit_of_measurement
-			if(this.config.unit_of_measurement) {
-				info.unit_of_measurement = this.config.unit_of_measurement;
-			}
-
 			// if this sensor is binary
 			if (this.type === "binary_sensor") {
 				info.payload_on = "true";
 				info.payload_off = "false";
 			}
 		}
+
+		// Support more discover options from home-assistant
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'unit_of_measurement',
+			'device_class',
+			'value_template',
+			'name',
+		].forEach((key) => {
+			if (this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
 
 		super.send_discover_msg(info);
 	}

--- a/devices/sensor.js
+++ b/devices/sensor.js
@@ -31,8 +31,8 @@ module.exports = class devSensor extends device {
 			info.state_topic = this.attributes["state"].full_mqtt_topic;
 
 			// optional unit_of_measurement
-			if (this.attributes["state"].unit_of_measurement) {
-				info.unit_of_measurement = this.attributes["state"].unit_of_measurement;
+			if(this.config.unit_of_measurement) {
+				info.unit_of_measurement = this.config.unit_of_measurement;
 			}
 
 			// if this sensor is binary


### PR DESCRIPTION
I've added some improvements to the homeassitant mqtt-discovery:

* Support for additional properties like `device_class` and `value_template`
* Fixed `last_value = 0`: If the PLC reports 0 for a newly added _device_ the value gets never published
* Add some fixes and an example how to publish a device with entities instead of single entities

![image](https://github.com/user-attachments/assets/7bcaea37-58c4-483f-86e5-8cf2303734bf)

Please let me know what you think. 