### PR TITLE
feat(devices): Add more home assistant device discovery options

### DIFF
--- a/devices/binaryCover.js
+++ b/devices/binaryCover.js
@@ -35,6 +35,18 @@ module.exports = class devBinaryCover extends device {
 		if (this.attributes["currentPosition"])
 			info.state_topic = this.attributes["currentPosition"].full_mqtt_topic;
 
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'value_template',
+			'name',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 		super.send_discover_msg(info);
 	}
 

--- a/devices/climate.js
+++ b/devices/climate.js
@@ -71,6 +71,20 @@ module.exports = class devLight extends device {
 				info.temperature_state_topic = this.attributes["target_temperature"].full_mqtt_topic;
 		}
 
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'value_template',
+			'current_temperature_template',
+			'temperature_command_template',
+			'name',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 		super.send_discover_msg(info);
 	}
 

--- a/devices/cover.js
+++ b/devices/cover.js
@@ -66,6 +66,17 @@ module.exports = class devCover extends device {
 		if (this.attributes["currentPosition"])
 			info.position_topic = this.attributes["currentPosition"].full_mqtt_topic;
 
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'name',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 		super.send_discover_msg(info);
 	}
 

--- a/devices/light.js
+++ b/devices/light.js
@@ -45,6 +45,21 @@ module.exports = class devLight extends device {
 				info.brightness_state_topic = this.attributes["brightness"].full_mqtt_topic;
 		}
 
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'value_template',
+			'command_template',
+			'brightness_value_template',
+			'brightness_command_template',
+			'name',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 		super.send_discover_msg(info);
 	}
 

--- a/devices/number.js
+++ b/devices/number.js
@@ -19,13 +19,7 @@ module.exports = class devNumber extends device {
 	}
 
 	send_discover_msg() {
-		let info = {
-			name: this.config.name,
-			min: this.config.min,
-			max: this.config.max,
-			step: this.config.step
-
-		};
+		let info = {};
 
 		if (this.attributes["state"]) {
 			// add only command_topic if the attribute is allowed to write
@@ -36,6 +30,25 @@ module.exports = class devNumber extends device {
 			if (this.attributes["state"].publish_to_mqtt)
 				info.state_topic = this.attributes["state"].full_mqtt_topic;
 		}
+
+		// Support more discover options from home-assistant
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'unit_of_measurement',
+			'device_class',
+			'value_template',
+			'command_template',
+			'name',
+			'mode',
+			'step',
+			'min',
+			'max',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 
 		super.send_discover_msg(info);
 	}

--- a/devices/sensor.js
+++ b/devices/sensor.js
@@ -37,7 +37,7 @@ module.exports = class devSensor extends device {
 			}
 		}
 
-		// Support more discover options from home-assistant
+		// Support home-assistant discover options
 		// https://www.home-assistant.io/integrations/mqtt/
 		[
 			'unit_of_measurement',

--- a/devices/switch.js
+++ b/devices/switch.js
@@ -34,6 +34,19 @@ module.exports = class devSwitch extends device {
 				info.state_topic = this.attributes["state"].full_mqtt_topic;
 		}
 
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'value_template',
+			'command_template',
+			'name',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
 		super.send_discover_msg(info);
 	}
 


### PR DESCRIPTION
This PR adds more options to configure the device discovery of home assistant. 

https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery

The options and values should match the JSON-Schema from #8 

closes #6 

