### PR TITLE
Add heater device

### DIFF
--- a/attribute.js
+++ b/attribute.js
@@ -81,7 +81,8 @@ module.exports = class attribute {
 				this.publish_to_mqtt = false;
 				break;
 
-			case "wr" || "rw":
+			case "rw":
+			case "wr":
 				this.write_to_s7 = true;
 				this.publish_to_mqtt = true;
 				break;

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -72,6 +72,7 @@ properties:
           enum:
             - binarycover
             - climate
+            - heater
             - cover
             - light
             - number
@@ -279,7 +280,6 @@ properties:
               value_template: *value_template
               mqtt: *mqtt
               manufacturer: *manufacturer
-              state: *state
               current_temperature: *state
               current_temperature_template: *value_template
               target_temperature: *state
@@ -287,8 +287,40 @@ properties:
             required:
               - type
               - name
-              - state
               - current_temperature
+              - target_temperature
+        # Heater specific schema
+        - if:
+            properties:
+              type:
+                const: "heater"
+          then:
+            additionalProperties: false
+            properties:
+              type:
+                const: "heater"
+              name: *name
+              device_name: *device_name
+              device_class: *device_class
+              value_template: *value_template
+              mqtt: *mqtt
+              manufacturer: *manufacturer
+              current_temperature: *state
+              current_temperature_template: *value_template
+              target_temperature: *state
+              temperature_command_template: *command_template
+              heatMode_temperature_threshold:
+                description: "The temperature threshold on which the heater will be set in heat mode"
+                type: number
+              min_temp:
+                description: "The minimum value of the heater widget in Home Assistant"
+                type: number
+              max_temp:
+                description: "The maximum value of the heater widget in Home Assistant"
+                type: number
+            required:
+              - type
+              - name
               - target_temperature
 
 required:

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -280,7 +280,6 @@ properties:
               value_template: *value_template
               mqtt: *mqtt
               manufacturer: *manufacturer
-              state: *state
               current_temperature: *state
               current_temperature_template: *value_template
               target_temperature: *state
@@ -322,7 +321,6 @@ properties:
             required:
               - type
               - name
-              - target_temperature
               - state
               - current_temperature
               - target_temperature

--- a/device_factory.js
+++ b/device_factory.js
@@ -4,6 +4,7 @@ let dev_cover = require('./devices/cover.js');
 let dev_sensor = require('./devices/sensor.js');
 let dev_switch = require('./devices/switch.js');
 let dev_climate = require('./devices/climate.js');
+let dev_heater = require('./devices/heater.js');
 let dev_binCover = require('./devices/binaryCover.js');
 let dev_number = require('./devices/number.js');
 
@@ -72,6 +73,9 @@ module.exports = function deviceFactory(devices, plc, mqtt, config, mqtt_base) {
 
 		case "climate":
 			return new dev_climate(plc, mqtt, config);
+
+		case "heater":
+			return new dev_heater(plc, mqtt, config);
 
 		case "binarycover":
 			return new dev_binCover(plc, mqtt, config);

--- a/devices/heater.js
+++ b/devices/heater.js
@@ -1,0 +1,120 @@
+const device = require("../device.js");
+const sf = require('../service_functions.js');
+
+/**
+ * Heater device
+ *
+ * The heater device is a simple climate entity that only has current and target temperature.
+ * The Mode "heat" and "off" gets derived from a config value "heatMode_temperature_threshold",
+ * when the target temperature is above this value, the mode is set to "heat" otherwise to "off".
+ */
+module.exports = class devHeater extends device {
+	constructor(plc, mqtt, config, mqtt_base) {
+		super(plc, mqtt, config, mqtt_base);
+
+		// current temperature
+		if (config["current_temperature"]) {
+			this.create_attribute(config["current_temperature"], this.getDatatype(config['current_temperature']), "current_temperature");
+			this.attributes["current_temperature"].set_RW("r");
+
+			// if no update interval is defined, set it to 5 min
+			if (this.attributes["current_temperature"].update_interval === 0)
+				this.attributes["current_temperature"].update_interval = 300_000;
+		}
+
+		// target temperature
+		if (config["target_temperature"]) {
+			this.create_attribute(config["target_temperature"], this.getDatatype(config['target_temperature']), "target_temperature");
+			this.attributes["target_temperature"].set_RW("rw");
+		}
+
+		// mode topic
+		this.modeStateTopic = this.full_mqtt_topic + "/mode";
+	}
+
+	/**
+	 * Derive the datatype from the plc config
+	 */
+	getDatatype(plcConfig) {
+		const identifier = plcConfig.plc || plcConfig;
+		const [,type] = identifier.split(',');
+		if(type.startsWith('INT')) {
+			return 'INT';
+		} else if(type.startsWith('REAL')) {
+			return 'REAL';
+		}
+		throw new Error(`Currently we support only INT and REAL datatypes. Got ${type}`);
+	}
+
+	rec_s7_data(attr, data) {
+		super.rec_s7_data(attr, data);
+		if(attr === 'target_temperature') {
+			this.updateMode(data);
+		}
+	}
+
+	rec_mqtt_data(attr, data) {
+		super.rec_mqtt_data(attr, data);
+		if(attr === 'target_temperature') {
+			this.updateMode(data);
+		}
+	}
+
+	/**
+	 * Update the mode based on the target temperature
+	 */
+	updateMode(targetTemperature) {
+		if(!Number.isFinite(targetTemperature)) {
+			// Set to heat if target-temp is gt than heatMode_temperature_threshold config value
+			const newMode = targetTemperature > (this.config.heatMode_temperature_threshold || 4) ? 'heat' : 'off';
+			sf.debug(`Setting mode to ${newMode} based on target temperature ${targetTemperature}`);
+			this.mqtt_handler.publish(this.modeStateTopic, newMode, {retain: true});
+			// HA updates the widget with current values on any mqtt messages
+			// We publish back the target_temperature before reading it from the PLC to avoid flickering
+			this.mqtt_handler.publish(this.attributes["target_temperature"].full_mqtt_topic, targetTemperature, {retain: true});
+		}
+	}
+
+	send_discover_msg() {
+		let info = {
+			name: this.name,
+			modes: ['off', 'heat'],
+			mode_state_topic: this.modeStateTopic,
+			mode_state_template: "{{ value }}", // Overwrite a potential set value_template to be able to publish raw strings
+		};
+
+		if (this.attributes["current_temperature"]) {
+			info.current_temperature_topic = this.attributes["current_temperature"].full_mqtt_topic;
+		}
+
+		if (this.attributes["target_temperature"]) {
+			// add only temperature_command_topic if the attribute is allowed to write
+			if (this.attributes["target_temperature"].write_to_s7)
+				info.temperature_command_topic = this.attributes["target_temperature"].full_mqtt_topic + "/set";
+
+			// add only temperature_state_topic if attribute is allowed to read
+			if (this.attributes["target_temperature"].publish_to_mqtt)
+				info.temperature_state_topic = this.attributes["target_temperature"].full_mqtt_topic;
+		}
+
+		// Support home-assistant discover options
+		// https://www.home-assistant.io/integrations/mqtt/
+		[
+			'device_class',
+			'value_template',
+			'current_temperature_template',
+			'temperature_command_template',
+			'name',
+			'min_temp',
+			'max_temp',
+		].forEach((key) => {
+			if(this.config[key]) {
+				info[key] = this.config[key];
+			}
+		});
+
+		super.send_discover_msg(info);
+	}
+
+
+}


### PR DESCRIPTION
This PR adds a dedicated heater device (but still climate entity).

* Only need current + target temperature
* Set the mode to "heat" or "off" depending on the target-temperature

This may be a bit my own use case so I decided to introduce a new device instead of changing the current climate device.

:exclamation: This PR also includes the commits of the other PRs so we should merge them first and I'll rebase this one afterwards. 