### PR TITLE
feat(config): Support yaml-anchors

### DIFF
--- a/config_handler.js
+++ b/config_handler.js
@@ -35,7 +35,7 @@ let config = function() {
 
         if (extension === "yaml" || extension === ".yml") {
             if (fs.existsSync(commander.opts().config)) {
-                return yaml.parse(fs.readFileSync(commander.opts().config, "utf8"));
+                return yaml.parse(fs.readFileSync(commander.opts().config, "utf8"), {merge: true});
             } else {
                 sf.error("Config file '" + commander.opts().config + "' not found")
             }
@@ -46,9 +46,9 @@ let config = function() {
         if (fs.existsSync('./config.json')) {
             return require('./config');
         } else if (fs.existsSync('./config.yaml')) {
-            return yaml.parse(fs.readFileSync('./config.yaml', "utf8"));
+            return yaml.parse(fs.readFileSync('./config.yaml', "utf8"), {merge: true});
         } else if (fs.existsSync('./config.yml')) {
-            return yaml.parse(fs.readFileSync('./config.yml', "utf8"));
+            return yaml.parse(fs.readFileSync('./config.yml', "utf8"), {merge: true});
         } else {
             sf.error("No config file found...")
         }


### PR DESCRIPTION
This enables support for yaml-anchros, for example:

```yaml
devices:
   - &heater_settings
     name: Wohnzimmer Heizung
     type: heater
     target_temperature: DB4,INT700
     value_template: "{{ (value | float / 10) | round(2) }}"
     temperature_command_template: "{{ (value * 10) | int }}"
     min_temp: 7
     max_temp: 30

   - <<: *heater_settings
     name: Gang Heizung
     target_temperature: DB4,INT702
```

which results in the correct config:

```js
[
  {
    name: 'Wohnzimmer Heizung',
    type: 'heater',
    target_temperature: 'DB4,INT700',
    value_template: '{{ (value | float / 10) | round(2) }}',
    temperature_command_template: '{{ (value * 10) | int }}',
    min_temp: 7,
    max_temp: 30
  },
  {
    name: 'Gang Heizung',
    type: 'heater',
    target_temperature: 'DB4,INT702',
    value_template: '{{ (value | float / 10) | round(2) }}',
    temperature_command_template: '{{ (value * 10) | int }}',
    min_temp: 7,
    max_temp: 30
  }
]

```